### PR TITLE
Add Configuration To Enable Subsonic legacyAuth API Support

### DIFF
--- a/tunesynctool/cli/main.py
+++ b/tunesynctool/cli/main.py
@@ -14,6 +14,7 @@ from tunesynctool.models.configuration import Configuration
 @click.option('--subsonic-port', 'subsonic_port', type=int, help='Port for the Subsonic server.')
 @click.option('--subsonic-username', 'subsonic_username', help='Username for the Subsonic server.')
 @click.option('--subsonic-password', 'subsonic_password', help='Password for the Subsonic server.')
+@click.option('--subsonic-legacy-auth', 'subsonic_legacy_auth', help='Whether to enable legacy authentication for the Subsonic server.')
 @click.option('--deezer-arl', 'deezer_arl', help='Deezer ARL token.')
 @click.option('--youtube-request-headers', 'youtube_request_headers', help='YouTube request headers.')
 @click.pass_context
@@ -26,6 +27,7 @@ def cli(
     subsonic_port: Optional[str],
     subsonic_username: Optional[str],
     subsonic_password: Optional[str],
+    subsonic_legacy_auth: Optional[bool],
     deezer_arl: Optional[str],
     youtube_request_headers: Optional[str]
     ):
@@ -41,6 +43,7 @@ def cli(
         subsonic_port=subsonic_port,
         subsonic_username=subsonic_username,
         subsonic_password=subsonic_password,
+        subsonic_legacy_auth=subsonic_legacy_auth,
         deezer_arl=deezer_arl,
         youtube_request_headers=youtube_request_headers,
     )

--- a/tunesynctool/drivers/common/subsonic/driver.py
+++ b/tunesynctool/drivers/common/subsonic/driver.py
@@ -43,6 +43,7 @@ class SubsonicDriver(ServiceDriver):
             port=self._config.subsonic_port,
             username=self._config.subsonic_username,
             password=self._config.subsonic_password,
+            legacyAuth=True
         )
     
     def get_user_playlists(self, limit: int = 25) -> List['Playlist']:

--- a/tunesynctool/drivers/common/subsonic/driver.py
+++ b/tunesynctool/drivers/common/subsonic/driver.py
@@ -43,7 +43,7 @@ class SubsonicDriver(ServiceDriver):
             port=self._config.subsonic_port,
             username=self._config.subsonic_username,
             password=self._config.subsonic_password,
-            legacyAuth=True
+            legacyAuth=self._config.subsonic_legacy_auth
         )
     
     def get_user_playlists(self, limit: int = 25) -> List['Playlist']:

--- a/tunesynctool/models/configuration.py
+++ b/tunesynctool/models/configuration.py
@@ -57,6 +57,11 @@ class Configuration:
     Password for the Subsonic server. Required for Subsonic API access.
     """
 
+    subsonic_legacy_auth: bool = field(default=False)
+    """
+    Enable legacy auth for Subsonic server. Required for some servers to authenticate.
+    """
+
     deezer_arl: Optional[str] = field(default=None)
     """
     Deezer ARL token. Required for Deezer API access.
@@ -83,6 +88,7 @@ class Configuration:
                 subsonic_port=int(os.getenv("SUBSONIC_PORT", cls.subsonic_port)),
                 subsonic_username=os.getenv("SUBSONIC_USERNAME"),
                 subsonic_password=os.getenv("SUBSONIC_PASSWORD"),
+                subsonic_legacy_auth=os.getenv("SUBSONIC_LEGACY_AUTH", False),
                 deezer_arl=os.getenv("DEEZER_ARL"),
                 youtube_request_headers=os.getenv("YOUTUBE_REQUEST_HEADERS")
             )


### PR DESCRIPTION
![](https://media1.tenor.com/m/D41V-g52DikAAAAC/star-wars-meme.gif)

## Description
Adds basic `legacyAuth` support for the libsonic API initialization, defaulting to `False` (the implicit default if we didn't provide the setting).

You still provide the API token as the password, but legacyAuth is required for whatever reason.

Open to any feedback, but this fixed it for my use case, of syncing with [LMS](https://github.com/epoupon/lms)