### PR TITLE
fix: prevent duplicate tracks when syncing to an existing Navidrome playlist (closes #7)

### DIFF
--- a/examples/copy_spotify_playlist_to_navidrome.py
+++ b/examples/copy_spotify_playlist_to_navidrome.py
@@ -39,14 +39,27 @@ for track in spotify_tracks:
     if matched_track:
         matched_tracks.append(matched_track)
 
-# Create a playlist in Navidrome
-navidrome_playlist = navidrome.create_playlist(spotify_playlist.name)
-
-# Add the tracks to Navidrome
-navidrome.add_tracks_to_playlist(
-    playlist_id=navidrome_playlist.service_id,
-    track_ids=[track.service_id for track in matched_tracks],
+# Get or create a playlist in Navidrome
+existing_playlists = navidrome.get_playlists()
+navidrome_playlist = next(
+    (p for p in existing_playlists if p.name == spotify_playlist.name),
+    None
 )
+
+if navidrome_playlist is None:
+    navidrome_playlist = navidrome.create_playlist(spotify_playlist.name)
+
+# Determine which tracks are not already in the playlist
+existing_tracks = navidrome.get_playlist_tracks(navidrome_playlist.service_id)
+existing_track_ids = {track.service_id for track in existing_tracks}
+new_tracks = [track for track in matched_tracks if track.service_id not in existing_track_ids]
+
+# Add only new tracks to Navidrome
+if new_tracks:
+    navidrome.add_tracks_to_playlist(
+        playlist_id=navidrome_playlist.service_id,
+        track_ids=[track.service_id for track in new_tracks],
+    )
 
 # Done! Your Spotify playlist has been copied to Navidrome
 # You can modify this script to work in reverse, so it


### PR DESCRIPTION
## What
Every time the sync script ran, it created a brand-new Navidrome playlist (or re-used one) and added **all** matched tracks without checking for existing entries. This caused duplicate tracks on subsequent runs.

## Fix
- Before creating a playlist, check whether one with the same name already exists in Navidrome.
- If it exists, reuse it; otherwise create a new one.
- Fetch the current tracks in the playlist and only add tracks whose `service_id` is not already present.

Closes #7